### PR TITLE
Update color scheme to red and black gradient theme

### DIFF
--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -69,10 +69,10 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
           >
             <CardContent className="p-4 text-center">
               <action.icon className="h-6 w-6 mx-auto mb-2 text-white" />
-              <div className="text-sm font-semibold text-gray-900 dark:text-white">
+              <div className="text-sm font-semibold text-white">
                 {action.label}
               </div>
-              <div className="text-xs text-gray-500 dark:text-gray-400">
+              <div className="text-xs text-white/80">
                 {action.desc}
               </div>
             </CardContent>

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -47,7 +47,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
       {/* Header Section */}
       <div className="text-center mb-8">
         <div className="inline-flex items-center gap-3 mb-4">
-          <div className="bg-gradient-to-r from-red-500 to-black p-3 rounded-2xl shadow-lg">
+          <div className="bg-gradient-to-r from-red-600 to-red-800 p-3 rounded-2xl shadow-lg">
             <Search className="h-8 w-8 text-white" />
           </div>
           <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-black to-red-600 dark:from-white dark:to-red-300 bg-clip-text text-transparent">

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -265,7 +265,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
           </p>
         </div>
         <div className="text-center p-4">
-          <div className="bg-gray-100 dark:bg-gray-900/20 rounded-full p-3 w-12 h-12 mx-auto mb-3">
+          <div className="bg-red-100 dark:bg-red-900/20 rounded-full p-3 w-12 h-12 mx-auto mb-3">
             <MapPin className="h-6 w-6 text-black dark:text-gray-400" />
           </div>
           <h4 className="font-semibold text-gray-900 dark:text-white mb-1">

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -43,7 +43,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
   ];
 
   return (
-    <div className="w-full max-w-7xl mx-auto">
+    <div className="w-full max-w-7xl mx-auto bg-red-500 rounded-3xl p-8">
       {/* Header Section */}
       <div className="text-center mb-8">
         <div className="inline-flex items-center gap-3 mb-4">

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -193,7 +193,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
                     </div>
 
                     <div className="flex justify-center">
-                      <div className="bg-gradient-to-r from-red-500 to-black p-3 rounded-full shadow-lg">
+                      <div className="bg-gradient-to-r from-red-700 to-black p-3 rounded-full shadow-lg">
                         <ArrowRight className="h-5 w-5 text-white" />
                       </div>
                     </div>

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -213,7 +213,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
                   <Button
                     type="submit"
                     disabled={!fromStop.trim() || !toStop.trim()}
-                    className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-black to-red-600 hover:from-gray-900 hover:to-red-700 text-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-red-700 to-black hover:from-red-800 hover:to-gray-900 text-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <NavigationIcon className="h-5 w-5 mr-2" />
                     Find Best Routes

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -84,7 +84,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
       <Card className="border-0 shadow-2xl bg-white dark:bg-gray-900 rounded-3xl overflow-hidden">
         <CardContent className="p-0">
           {/* Tab Selection */}
-          <div className="bg-gradient-to-r from-red-500 to-black p-6">
+          <div className="bg-red-500 p-6">
             <div className="flex gap-2 bg-white/20 backdrop-blur-sm rounded-2xl p-2">
               <button
                 onClick={() => setActiveTab("number")}

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -140,7 +140,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
                   <Button
                     type="submit"
                     disabled={!busNumber.trim()}
-                    className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-red-700 to-red-900 hover:from-red-800 hover:to-black text-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full h-14 text-lg font-semibold bg-white text-red-500 hover:bg-gray-50 hover:text-red-600 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <Zap className="h-5 w-5 mr-2" />
                     Track This Bus

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -47,7 +47,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
       {/* Header Section */}
       <div className="text-center mb-8">
         <div className="inline-flex items-center gap-3 mb-4">
-          <div className="bg-gradient-to-r from-red-600 to-red-800 p-3 rounded-2xl shadow-lg">
+          <div className="bg-red-500 p-3 rounded-2xl shadow-lg">
             <Search className="h-8 w-8 text-white" />
           </div>
           <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-red-700 to-red-500 dark:from-red-400 dark:to-red-200 bg-clip-text text-transparent">

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -68,7 +68,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
             className="hover:shadow-lg transition-all duration-300 hover:scale-105 border-0 bg-gradient-to-br from-red-100 to-red-50 dark:from-gray-800 dark:to-gray-700"
           >
             <CardContent className="p-4 text-center">
-              <action.icon className="h-6 w-6 mx-auto mb-2 text-red-600 dark:text-red-400" />
+              <action.icon className="h-6 w-6 mx-auto mb-2 text-red-700 dark:text-red-300" />
               <div className="text-sm font-semibold text-gray-900 dark:text-white">
                 {action.label}
               </div>

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -213,7 +213,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
                   <Button
                     type="submit"
                     disabled={!fromStop.trim() || !toStop.trim()}
-                    className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-red-700 to-black hover:from-red-800 hover:to-gray-900 text-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full h-14 text-lg font-semibold bg-white text-red-500 hover:bg-gray-50 hover:text-red-600 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <NavigationIcon className="h-5 w-5 mr-2" />
                     Find Best Routes

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -50,7 +50,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
           <div className="bg-gradient-to-r from-red-600 to-red-800 p-3 rounded-2xl shadow-lg">
             <Search className="h-8 w-8 text-white" />
           </div>
-          <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-black to-red-600 dark:from-white dark:to-red-300 bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-red-700 to-red-500 dark:from-red-400 dark:to-red-200 bg-clip-text text-transparent">
             Find Your Bus
           </h2>
         </div>

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -65,7 +65,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
         {quickActions.map((action, index) => (
           <Card
             key={index}
-            className="hover:shadow-lg transition-all duration-300 hover:scale-105 border-0 bg-gradient-to-br from-red-100 to-red-50 dark:from-gray-800 dark:to-gray-700"
+            className="hover:shadow-lg transition-all duration-300 hover:scale-105 border-0 bg-white/20 backdrop-blur-sm"
           >
             <CardContent className="p-4 text-center">
               <action.icon className="h-6 w-6 mx-auto mb-2 text-red-700 dark:text-red-300" />

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -50,7 +50,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
           <div className="bg-red-500 p-3 rounded-2xl shadow-lg">
             <Search className="h-8 w-8 text-white" />
           </div>
-          <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-red-700 to-red-500 dark:from-red-400 dark:to-red-200 bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-5xl font-bold text-white">
             Find Your Bus
           </h2>
         </div>

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -140,7 +140,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
                   <Button
                     type="submit"
                     disabled={!busNumber.trim()}
-                    className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-red-500 to-black hover:from-red-600 hover:to-gray-900 text-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-red-700 to-red-900 hover:from-red-800 hover:to-black text-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <Zap className="h-5 w-5 mr-2" />
                     Track This Bus

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -65,7 +65,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
         {quickActions.map((action, index) => (
           <Card
             key={index}
-            className="hover:shadow-lg transition-all duration-300 hover:scale-105 border-0 bg-gradient-to-br from-red-50 to-gray-50 dark:from-gray-800 dark:to-gray-700"
+            className="hover:shadow-lg transition-all duration-300 hover:scale-105 border-0 bg-gradient-to-br from-red-100 to-red-50 dark:from-gray-800 dark:to-gray-700"
           >
             <CardContent className="p-4 text-center">
               <action.icon className="h-6 w-6 mx-auto mb-2 text-red-600 dark:text-red-400" />

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -72,9 +72,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
               <div className="text-sm font-semibold text-white">
                 {action.label}
               </div>
-              <div className="text-xs text-white/80">
-                {action.desc}
-              </div>
+              <div className="text-xs text-white/80">{action.desc}</div>
             </CardContent>
           </Card>
         ))}

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -54,7 +54,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
             Find Your Bus
           </h2>
         </div>
-        <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+        <p className="text-lg text-white/90 max-w-2xl mx-auto">
           Search by bus number or plan your route between stops. Get real-time
           updates and never miss your ride.
         </p>

--- a/client/components/BusSearchForm.tsx
+++ b/client/components/BusSearchForm.tsx
@@ -68,7 +68,7 @@ export default function BusSearchForm({ onSearch }: BusSearchFormProps) {
             className="hover:shadow-lg transition-all duration-300 hover:scale-105 border-0 bg-white/20 backdrop-blur-sm"
           >
             <CardContent className="p-4 text-center">
-              <action.icon className="h-6 w-6 mx-auto mb-2 text-red-700 dark:text-red-300" />
+              <action.icon className="h-6 w-6 mx-auto mb-2 text-white" />
               <div className="text-sm font-semibold text-gray-900 dark:text-white">
                 {action.label}
               </div>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -306,7 +306,7 @@ export default function FAQ() {
                       className="border-0 bg-gradient-to-br from-red-600 to-black rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
                     >
                       <AccordionTrigger className="px-6 py-4 hover:no-underline">
-                        <span className="text-left font-semibold text-lg">
+                        <span className="text-left font-semibold text-lg text-white">
                           {faq.question}
                         </span>
                       </AccordionTrigger>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -212,7 +212,7 @@ export default function FAQ() {
               </span>
               <span className="mx-auto"> Questions</span>
             </h1>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-8">
+            <p className="text-xl text-white/90 max-w-3xl mx-auto mb-8">
               Find answers to common questions about{" "}
               <span className="text-black dark:text-white font-semibold">
                 Bus

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -227,7 +227,7 @@ export default function FAQ() {
                 <HelpCircle className="h-3 w-3 mr-1" />
                 Instant Answers
               </Badge>
-              <Badge className="text-sm bg-green-500 text-white hover:bg-green-600 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-black text-white hover:bg-gray-800 transition-colors px-4 py-2 font-semibold">
                 <MessageCircle className="h-3 w-3 mr-1" />
                 24/7 Support
               </Badge>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -207,20 +207,14 @@ export default function FAQ() {
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">
             <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 flex flex-col">
-              <span className="text-white">
-                Frequently Asked
-              </span>
+              <span className="text-white">Frequently Asked</span>
               <span className="mx-auto"> Questions</span>
             </h1>
             <p className="text-xl text-white/90 max-w-3xl mx-auto mb-8">
               Find answers to common questions about{" "}
-              <span className="text-white font-semibold">
-                Bus
-              </span>
-              <span className="text-white font-semibold">
-                नियोजक
-              </span>
-              . Can't find what you're looking for? Contact our support team!
+              <span className="text-white font-semibold">Bus</span>
+              <span className="text-white font-semibold">नियोजक</span>. Can't
+              find what you're looking for? Contact our support team!
             </p>
             <div className="flex flex-wrap justify-center gap-3 mb-8">
               <Badge className="text-sm bg-white text-red-500 hover:bg-gray-50 transition-colors px-4 py-2 font-semibold">
@@ -250,12 +244,12 @@ export default function FAQ() {
                 className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-white rounded-2xl hover:scale-[1.02]"
               >
                 <CardHeader className="text-center">
-                  <div
-                    className="bg-red-500 text-white p-4 rounded-xl w-16 h-16 mx-auto mb-4 flex items-center justify-center shadow-lg"
-                  >
+                  <div className="bg-red-500 text-white p-4 rounded-xl w-16 h-16 mx-auto mb-4 flex items-center justify-center shadow-lg">
                     <category.icon className="h-8 w-8" />
                   </div>
-                  <CardTitle className="text-lg text-gray-900">{category.title}</CardTitle>
+                  <CardTitle className="text-lg text-gray-900">
+                    {category.title}
+                  </CardTitle>
                   <p className="text-sm text-gray-600">
                     {category.questions.length} questions answered
                   </p>
@@ -288,9 +282,7 @@ export default function FAQ() {
                 className="scroll-mt-24 max-w-4xl mx-auto"
               >
                 <div className="flex items-center justify-center space-x-4 mb-8">
-                  <div
-                    className="bg-red-500 text-white p-3 rounded-xl shadow-lg"
-                  >
+                  <div className="bg-red-500 text-white p-3 rounded-xl shadow-lg">
                     <category.icon className="h-6 w-6" />
                   </div>
                   <h2 className="text-3xl font-bold text-gray-900 text-center">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -306,7 +306,7 @@ export default function FAQ() {
                       className="border-0 bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
                     >
                       <AccordionTrigger className="px-6 py-4 hover:no-underline">
-                        <span className="text-left font-semibold text-lg text-white">
+                        <span className="text-left font-semibold text-lg text-gray-900">
                           {faq.question}
                         </span>
                       </AccordionTrigger>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -247,7 +247,7 @@ export default function FAQ() {
             {faqCategories.map((category, index) => (
               <Card
                 key={category.id}
-                className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-gradient-to-br from-white to-blue-50 dark:from-gray-800 dark:to-blue-950/20 rounded-2xl hover:scale-[1.02]"
+                className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-gradient-to-br from-white to-red-50 dark:from-gray-800 dark:to-red-950/20 rounded-2xl hover:scale-[1.02]"
               >
                 <CardHeader className="text-center">
                   <div

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -247,7 +247,7 @@ export default function FAQ() {
             {faqCategories.map((category, index) => (
               <Card
                 key={category.id}
-                className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-gradient-to-br from-red-600 to-black rounded-2xl hover:scale-[1.02]"
+                className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-white rounded-2xl hover:scale-[1.02]"
               >
                 <CardHeader className="text-center">
                   <div

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -311,7 +311,7 @@ export default function FAQ() {
                         </span>
                       </AccordionTrigger>
                       <AccordionContent className="px-6 pb-6">
-                        <p className="text-muted-foreground leading-relaxed">
+                        <p className="text-white/90 leading-relaxed">
                           {faq.answer}
                         </p>
                       </AccordionContent>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -293,7 +293,7 @@ export default function FAQ() {
                   >
                     <category.icon className="h-6 w-6" />
                   </div>
-                  <h2 className="text-3xl font-bold text-white text-center">
+                  <h2 className="text-3xl font-bold text-gray-900 text-center">
                     {category.title}
                   </h2>
                 </div>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -303,7 +303,7 @@ export default function FAQ() {
                     <AccordionItem
                       key={index}
                       value={`${category.id}-${index}`}
-                      className="border-0 bg-gradient-to-br from-white to-red-50 dark:from-gray-800 dark:to-red-950/20 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
+                      className="border-0 bg-gradient-to-br from-red-600 to-black rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
                     >
                       <AccordionTrigger className="px-6 py-4 hover:no-underline">
                         <span className="text-left font-semibold text-lg">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -214,10 +214,10 @@ export default function FAQ() {
             </h1>
             <p className="text-xl text-white/90 max-w-3xl mx-auto mb-8">
               Find answers to common questions about{" "}
-              <span className="text-black dark:text-white font-semibold">
+              <span className="text-white font-semibold">
                 Bus
               </span>
-              <span className="text-red-600 dark:text-red-400 font-semibold">
+              <span className="text-white font-semibold">
                 नियोजक
               </span>
               . Can't find what you're looking for? Contact our support team!

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -338,7 +338,7 @@ export default function FAQ() {
             <Button
               variant="secondary"
               size="lg"
-              className="bg-white text-red-700 hover:bg-red-50 hover:text-red-800 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
+              className="bg-white text-red-500 hover:bg-gray-50 hover:text-red-600 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
               asChild
             >
               <Link to="/contact">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -207,7 +207,7 @@ export default function FAQ() {
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">
             <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 flex flex-col">
-              <span className="text-gradient bg-gradient-to-r from-red-700 to-black bg-clip-text text-transparent">
+              <span className="text-white">
                 Frequently Asked
               </span>
               <span className="mx-auto"> Questions</span>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -311,7 +311,7 @@ export default function FAQ() {
                         </span>
                       </AccordionTrigger>
                       <AccordionContent className="px-6 pb-6">
-                        <p className="text-white/90 leading-relaxed">
+                        <p className="text-gray-700 leading-relaxed">
                           {faq.answer}
                         </p>
                       </AccordionContent>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -338,7 +338,7 @@ export default function FAQ() {
             <Button
               variant="secondary"
               size="lg"
-              className="bg-white text-blue-600 hover:bg-blue-50 hover:text-blue-700 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
+              className="bg-white text-red-600 hover:bg-red-50 hover:text-red-700 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
               asChild
             >
               <Link to="/contact">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -256,7 +256,7 @@ export default function FAQ() {
                     <category.icon className="h-8 w-8" />
                   </div>
                   <CardTitle className="text-lg text-white">{category.title}</CardTitle>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-white/80">
                     {category.questions.length} questions answered
                   </p>
                 </CardHeader>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -289,7 +289,7 @@ export default function FAQ() {
               >
                 <div className="flex items-center justify-center space-x-4 mb-8">
                   <div
-                    className={`bg-gradient-to-br ${category.color} text-white p-3 rounded-xl shadow-lg`}
+                    className="bg-red-500 text-white p-3 rounded-xl shadow-lg"
                   >
                     <category.icon className="h-6 w-6" />
                   </div>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -176,7 +176,7 @@ export default function FAQ() {
         {
           question: "How can I report incorrect bus information?",
           answer:
-            "Please use our contact form or email us at support@busन��योजक.com with specific details about the incorrect information. Include bus number, route, and what needs to be corrected. We typically fix issues within 24 hours.",
+            "Please use our contact form or email us at support@busनियोजक.com with specific details about the incorrect information. Include bus number, route, and what needs to be corrected. We typically fix issues within 24 hours.",
         },
         {
           question: "Can I suggest new features?",
@@ -231,7 +231,7 @@ export default function FAQ() {
                 <MessageCircle className="h-3 w-3 mr-1" />
                 24/7 Support
               </Badge>
-              <Badge className="text-sm bg-red-700 text-white hover:bg-red-800 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-white text-red-500 hover:bg-gray-50 transition-colors px-4 py-2 font-semibold">
                 <Users className="h-3 w-3 mr-1" />
                 Community Help
               </Badge>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -251,7 +251,7 @@ export default function FAQ() {
               >
                 <CardHeader className="text-center">
                   <div
-                    className={`bg-gradient-to-br ${category.color} text-white p-4 rounded-xl w-16 h-16 mx-auto mb-4 flex items-center justify-center shadow-lg`}
+                    className="bg-red-500 text-white p-4 rounded-xl w-16 h-16 mx-auto mb-4 flex items-center justify-center shadow-lg"
                   >
                     <category.icon className="h-8 w-8" />
                   </div>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -349,7 +349,7 @@ export default function FAQ() {
             <Button
               variant="secondary"
               size="lg"
-              className="bg-white text-blue-600 hover:bg-blue-50 hover:text-blue-700 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
+              className="bg-white text-black hover:bg-gray-50 hover:text-gray-800 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
               asChild
             >
               <a href="tel:+919876543210">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -176,7 +176,7 @@ export default function FAQ() {
         {
           question: "How can I report incorrect bus information?",
           answer:
-            "Please use our contact form or email us at support@busनियोजक.com with specific details about the incorrect information. Include bus number, route, and what needs to be corrected. We typically fix issues within 24 hours.",
+            "Please use our contact form or email us at support@busन��योजक.com with specific details about the incorrect information. Include bus number, route, and what needs to be corrected. We typically fix issues within 24 hours.",
         },
         {
           question: "Can I suggest new features?",
@@ -227,7 +227,7 @@ export default function FAQ() {
                 <HelpCircle className="h-3 w-3 mr-1" />
                 Instant Answers
               </Badge>
-              <Badge className="text-sm bg-black text-white hover:bg-gray-800 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-white text-red-500 hover:bg-gray-50 transition-colors px-4 py-2 font-semibold">
                 <MessageCircle className="h-3 w-3 mr-1" />
                 24/7 Support
               </Badge>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -325,7 +325,7 @@ export default function FAQ() {
       </section>
 
       {/* Contact Support Section */}
-      <section className="py-16 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
+      <section className="py-16 bg-gradient-to-r from-red-600 to-black text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-6">
             Still Need Help?

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -247,7 +247,7 @@ export default function FAQ() {
             {faqCategories.map((category, index) => (
               <Card
                 key={category.id}
-                className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-gradient-to-br from-white to-red-50 dark:from-gray-800 dark:to-red-950/20 rounded-2xl hover:scale-[1.02]"
+                className="shadow-lg hover:shadow-xl transition-all duration-300 border-0 bg-gradient-to-br from-red-600 to-black rounded-2xl hover:scale-[1.02]"
               >
                 <CardHeader className="text-center">
                   <div

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -263,7 +263,7 @@ export default function FAQ() {
                 <CardContent className="pt-0">
                   <Button
                     variant="outline"
-                    className="w-full hover:bg-gradient-to-r hover:from-red-50 hover:to-gray-50 hover:border-red-300 transition-all duration-200"
+                    className="w-full bg-white text-red-500 hover:bg-gray-50 hover:text-red-600 border-white transition-all duration-200"
                     onClick={() => {
                       document
                         .getElementById(`category-${category.id}`)

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -263,7 +263,7 @@ export default function FAQ() {
                 <CardContent className="pt-0">
                   <Button
                     variant="outline"
-                    className="w-full hover:bg-gradient-to-r hover:from-blue-50 hover:to-purple-50 hover:border-blue-300 transition-all duration-200"
+                    className="w-full hover:bg-gradient-to-r hover:from-red-50 hover:to-gray-50 hover:border-red-300 transition-all duration-200"
                     onClick={() => {
                       document
                         .getElementById(`category-${category.id}`)

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -293,7 +293,7 @@ export default function FAQ() {
                   >
                     <category.icon className="h-6 w-6" />
                   </div>
-                  <h2 className="text-3xl font-bold text-foreground dark:text-white text-center">
+                  <h2 className="text-3xl font-bold text-white text-center">
                     {category.title}
                   </h2>
                 </div>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -256,7 +256,7 @@ export default function FAQ() {
                     <category.icon className="h-8 w-8" />
                   </div>
                   <CardTitle className="text-lg text-gray-900">{category.title}</CardTitle>
-                  <p className="text-sm text-white/80">
+                  <p className="text-sm text-gray-600">
                     {category.questions.length} questions answered
                   </p>
                 </CardHeader>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -202,7 +202,7 @@ export default function FAQ() {
       <Navigation />
 
       {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
+      <section className="relative overflow-hidden bg-gradient-to-br from-red-50 via-white to-gray-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
         <div className="absolute inset-0 bg-grid-pattern opacity-5"></div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -206,7 +206,7 @@ export default function FAQ() {
         <div className="absolute inset-0 bg-grid-pattern opacity-5"></div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">
-            <h1 className="text-4xl md:text-6xl font-bold text-black dark:text-white mb-6 flex flex-col">
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 flex flex-col">
               <span className="text-gradient bg-gradient-to-r from-red-700 to-black bg-clip-text text-transparent">
                 Frequently Asked
               </span>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -255,7 +255,7 @@ export default function FAQ() {
                   >
                     <category.icon className="h-8 w-8" />
                   </div>
-                  <CardTitle className="text-lg">{category.title}</CardTitle>
+                  <CardTitle className="text-lg text-white">{category.title}</CardTitle>
                   <p className="text-sm text-muted-foreground">
                     {category.questions.length} questions answered
                   </p>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -171,7 +171,7 @@ export default function FAQ() {
       id: "support",
       title: "Support & Feedback",
       icon: Users,
-      color: "from-indigo-500 to-blue-500",
+      color: "from-gray-800 to-red-500",
       questions: [
         {
           question: "How can I report incorrect bus information?",

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -207,7 +207,7 @@ export default function FAQ() {
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">
             <h1 className="text-4xl md:text-6xl font-bold text-black dark:text-white mb-6 flex flex-col">
-              <span className="text-gradient bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+              <span className="text-gradient bg-gradient-to-r from-red-600 to-black bg-clip-text text-transparent">
                 Frequently Asked
               </span>
               <span className="mx-auto"> Questions</span>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -241,7 +241,7 @@ export default function FAQ() {
       </section>
 
       {/* FAQ Categories */}
-      <section className="py-16 bg-background dark:bg-gray-950">
+      <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
             {faqCategories.map((category, index) => (

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -231,7 +231,7 @@ export default function FAQ() {
                 <MessageCircle className="h-3 w-3 mr-1" />
                 24/7 Support
               </Badge>
-              <Badge className="text-sm bg-purple-500 text-white hover:bg-purple-600 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-red-600 text-white hover:bg-red-700 transition-colors px-4 py-2 font-semibold">
                 <Users className="h-3 w-3 mr-1" />
                 Community Help
               </Badge>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -202,7 +202,7 @@ export default function FAQ() {
       <Navigation />
 
       {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-red-50 via-white to-gray-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
+      <section className="relative overflow-hidden bg-red-500">
         <div className="absolute inset-0 bg-grid-pattern opacity-5"></div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -31,7 +31,7 @@ export default function FAQ() {
       id: "general",
       title: "General Information",
       icon: HelpCircle,
-      color: "from-red-500 to-black",
+      color: "from-red-700 to-black",
       questions: [
         {
           question: "What is Busनियोजक?",
@@ -59,7 +59,7 @@ export default function FAQ() {
       id: "search",
       title: "Bus Search & Routes",
       icon: Search,
-      color: "from-black to-red-500",
+      color: "from-red-700 to-black",
       questions: [
         {
           question: "How do I search for a specific bus?",
@@ -87,7 +87,7 @@ export default function FAQ() {
       id: "tracking",
       title: "Live Tracking",
       icon: MapPin,
-      color: "from-red-600 to-black",
+      color: "from-red-700 to-black",
       questions: [
         {
           question: "How does live bus tracking work?",
@@ -115,7 +115,7 @@ export default function FAQ() {
       id: "mobile",
       title: "Mobile App & Website",
       icon: Smartphone,
-      color: "from-black to-red-600",
+      color: "from-red-700 to-black",
       questions: [
         {
           question: "Is there a mobile app available?",
@@ -143,7 +143,7 @@ export default function FAQ() {
       id: "account",
       title: "Account & Privacy",
       icon: Shield,
-      color: "from-red-500 to-gray-600",
+      color: "from-red-700 to-black",
       questions: [
         {
           question: "Do I need to create an account?",
@@ -171,7 +171,7 @@ export default function FAQ() {
       id: "support",
       title: "Support & Feedback",
       icon: Users,
-      color: "from-gray-800 to-red-500",
+      color: "from-red-700 to-black",
       questions: [
         {
           question: "How can I report incorrect bus information?",
@@ -207,7 +207,7 @@ export default function FAQ() {
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center mb-8">
             <h1 className="text-4xl md:text-6xl font-bold text-black dark:text-white mb-6 flex flex-col">
-              <span className="text-gradient bg-gradient-to-r from-red-600 to-black bg-clip-text text-transparent">
+              <span className="text-gradient bg-gradient-to-r from-red-700 to-black bg-clip-text text-transparent">
                 Frequently Asked
               </span>
               <span className="mx-auto"> Questions</span>
@@ -223,7 +223,7 @@ export default function FAQ() {
               . Can't find what you're looking for? Contact our support team!
             </p>
             <div className="flex flex-wrap justify-center gap-3 mb-8">
-              <Badge className="text-sm bg-red-500 text-white hover:bg-red-600 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-red-700 text-white hover:bg-red-800 transition-colors px-4 py-2 font-semibold">
                 <HelpCircle className="h-3 w-3 mr-1" />
                 Instant Answers
               </Badge>
@@ -231,7 +231,7 @@ export default function FAQ() {
                 <MessageCircle className="h-3 w-3 mr-1" />
                 24/7 Support
               </Badge>
-              <Badge className="text-sm bg-red-600 text-white hover:bg-red-700 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-red-700 text-white hover:bg-red-800 transition-colors px-4 py-2 font-semibold">
                 <Users className="h-3 w-3 mr-1" />
                 Community Help
               </Badge>
@@ -325,7 +325,7 @@ export default function FAQ() {
       </section>
 
       {/* Contact Support Section */}
-      <section className="py-16 bg-gradient-to-r from-red-600 to-black text-white">
+      <section className="py-16 bg-gradient-to-r from-red-700 to-black text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-6">
             Still Need Help?
@@ -338,7 +338,7 @@ export default function FAQ() {
             <Button
               variant="secondary"
               size="lg"
-              className="bg-white text-red-600 hover:bg-red-50 hover:text-red-700 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
+              className="bg-white text-red-700 hover:bg-red-50 hover:text-red-800 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
               asChild
             >
               <Link to="/contact">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -349,7 +349,7 @@ export default function FAQ() {
             <Button
               variant="secondary"
               size="lg"
-              className="bg-white text-black hover:bg-gray-50 hover:text-gray-800 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
+              className="bg-white text-red-500 hover:bg-gray-50 hover:text-red-600 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02]"
               asChild
             >
               <a href="tel:+919876543210">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -325,7 +325,7 @@ export default function FAQ() {
       </section>
 
       {/* Contact Support Section */}
-      <section className="py-16 bg-gradient-to-r from-red-700 to-black text-white">
+      <section className="py-16 bg-red-500 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-6">
             Still Need Help?

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -263,7 +263,7 @@ export default function FAQ() {
                 <CardContent className="pt-0">
                   <Button
                     variant="outline"
-                    className="w-full bg-white text-red-500 hover:bg-gray-50 hover:text-red-600 border-white transition-all duration-200"
+                    className="w-full bg-red-500 text-white hover:bg-red-600 transition-all duration-200"
                     onClick={() => {
                       document
                         .getElementById(`category-${category.id}`)

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -303,7 +303,7 @@ export default function FAQ() {
                     <AccordionItem
                       key={index}
                       value={`${category.id}-${index}`}
-                      className="border-0 bg-gradient-to-br from-red-600 to-black rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
+                      className="border-0 bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
                     >
                       <AccordionTrigger className="px-6 py-4 hover:no-underline">
                         <span className="text-left font-semibold text-lg text-white">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -303,7 +303,7 @@ export default function FAQ() {
                     <AccordionItem
                       key={index}
                       value={`${category.id}-${index}`}
-                      className="border-0 bg-gradient-to-br from-white to-blue-50 dark:from-gray-800 dark:to-blue-950/20 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
+                      className="border-0 bg-gradient-to-br from-white to-red-50 dark:from-gray-800 dark:to-red-950/20 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
                     >
                       <AccordionTrigger className="px-6 py-4 hover:no-underline">
                         <span className="text-left font-semibold text-lg">

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -223,7 +223,7 @@ export default function FAQ() {
               . Can't find what you're looking for? Contact our support team!
             </p>
             <div className="flex flex-wrap justify-center gap-3 mb-8">
-              <Badge className="text-sm bg-red-700 text-white hover:bg-red-800 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-white text-red-500 hover:bg-gray-50 transition-colors px-4 py-2 font-semibold">
                 <HelpCircle className="h-3 w-3 mr-1" />
                 Instant Answers
               </Badge>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -223,7 +223,7 @@ export default function FAQ() {
               . Can't find what you're looking for? Contact our support team!
             </p>
             <div className="flex flex-wrap justify-center gap-3 mb-8">
-              <Badge className="text-sm bg-blue-500 text-white hover:bg-blue-600 transition-colors px-4 py-2 font-semibold">
+              <Badge className="text-sm bg-red-500 text-white hover:bg-red-600 transition-colors px-4 py-2 font-semibold">
                 <HelpCircle className="h-3 w-3 mr-1" />
                 Instant Answers
               </Badge>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -255,7 +255,7 @@ export default function FAQ() {
                   >
                     <category.icon className="h-8 w-8" />
                   </div>
-                  <CardTitle className="text-lg text-white">{category.title}</CardTitle>
+                  <CardTitle className="text-lg text-gray-900">{category.title}</CardTitle>
                   <p className="text-sm text-white/80">
                     {category.questions.length} questions answered
                   </p>

--- a/client/pages/FAQ.tsx
+++ b/client/pages/FAQ.tsx
@@ -143,7 +143,7 @@ export default function FAQ() {
       id: "account",
       title: "Account & Privacy",
       icon: Shield,
-      color: "from-yellow-500 to-amber-500",
+      color: "from-red-500 to-gray-600",
       questions: [
         {
           question: "Do I need to create an account?",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -66,7 +66,7 @@ export default function Index() {
       {/* Hero Section */}
       <section className="relative overflow-hidden bg-white dark:bg-gray-950">
         <div className="absolute inset-0 bg-grid-pattern opacity-5"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 pb-7">
           <div className="text-center mb-12">
             <h1 className="text-4xl md:text-6xl font-bold text-black dark:text-white mb-6">
               Welcome to <span className="text-black dark:text-white">Bus</span>


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR implements a comprehensive color scheme update to replace the existing blue/purple gradient theme with a red and black gradient design. The users specifically requested to change colors for the "Find Your Bus" section, "Track This" button, and help page while maintaining the existing design structure.

## Code changes
- **BusSearchForm.tsx**: Updated the entire component color scheme from blue/purple gradients to red/black theme
  - Changed main container background to red with rounded corners
  - Updated header section with red background and white text
  - Modified search icon container and button colors to use red/white scheme
  - Changed tab selection colors from blue/purple to red/black
  - Updated input field focus colors to red variants
  - Modified feature icons and backgrounds to use red/black color palette

- **FAQ.tsx**: Transformed the help page color scheme to match the new theme
  - Updated all category gradient colors from various colors to consistent red-to-black gradients
  - Changed hero section background from blue/purple to red/gray gradients
  - Modified badges and buttons to use red/black color scheme
  - Updated contact support section background to solid red
  - Maintained all existing functionality while applying the new visual theme

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/18531d4fdef743d7b06ee93dbc3c3a14/zenith-hub)

👀 [Preview Link](https://18531d4fdef743d7b06ee93dbc3c3a14-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>18531d4fdef743d7b06ee93dbc3c3a14</projectId>-->
<!--<branchName>zenith-hub</branchName>-->